### PR TITLE
Enabled offline singleR testing: Moved to tar.gz instead of directory…

### DIFF
--- a/conf/test_offline.config
+++ b/conf/test_offline.config
@@ -28,8 +28,8 @@ params {
     integration_methods = 'scvi,harmony,bbknn,combat'
     doublet_detection   = 'solo,scrublet,doubletdetection,scds'
     celltypist_model    = 'Adult_Human_Skin'
-    celldex_reference   = 'celldex_references/celldex_hpca__2024-02-26_h5_se' // using a locally stored celldex reference for this one. The output should be identical to test_full profile
-    celldex_reference_label = 'label.fine'
+    celldex_reference   = 'https://github.com/addityea/test-datasets/raw/refs/heads/scdownstream/misc/celldex_hpca__2024-02-26_h5_se.tar.gz,https://github.com/addityea/test-datasets/raw/refs/heads/scdownstream/misc/celldex_monaco_immune__2024-02-26_h5_se.tar.gz' // using a locally stored celldex reference for this one. The output should be identical to test_full profile
+    celldex_reference_label = 'label.fine,label.main'
     integration_hvgs    = 500
 }
 

--- a/modules/local/celltypes/celldexdownload/main.nf
+++ b/modules/local/celltypes/celldexdownload/main.nf
@@ -11,10 +11,8 @@ process CELLTYPES_CELLDEXDOWNLOAD {
     val(ref)
 
     output:
-    path("celldex_${ref}_h5_se/assays.h5"), emit: h5
-    path("celldex_${ref}_h5_se/se.rds"),    emit: rds
-    path("celldex_${ref}_h5_se"),           emit: refdir
-    path "versions.yml"           , emit: versions
+    path("celldex_${ref}_h5_se.tar.gz"),        emit: tar
+    path "versions.yml",                        emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,8 +25,6 @@ process CELLTYPES_CELLDEXDOWNLOAD {
     def args = task.ext.args ?: ''
 
     """
-    mkdir -p celldex_${ref}_h5_se
-    touch "celldex_${ref}_h5_se/assays.h5"
-    touch "celldex_${ref}_h5_se/se.rds"
+    touch "celldex_${ref}_h5_se.tar.gz"
     """
 }

--- a/modules/local/celltypes/celldexdownload/templates/celldexDownload.R
+++ b/modules/local/celltypes/celldexdownload/templates/celldexDownload.R
@@ -16,6 +16,9 @@ saveHDF5SummarizedExperiment(
   dir = paste0("celldex_", r, "_h5_se"),
   replace = TRUE
 )
+# Compress the HDF5 files into a tar.gz archive
+tar(tarfile = paste0("celldex_", r, "_h5_se.tar.gz"), files = paste0("celldex_", r, "_h5_se"))
+
 # Capturing version information, as before
 versions <- list(
   "${task.process}" = list(

--- a/modules/local/celltypes/singler/templates/singleR.R
+++ b/modules/local/celltypes/singler/templates/singleR.R
@@ -43,8 +43,11 @@ for (ref_idx in seq_along(references)) {
   reflabel <- reference_labels[ref_idx]
   ref_name <- strsplit(ref, "__")[[1]][1]
   ref_ver <- strsplit(ref, "__")[[1]][2]
+  # Untar the reference files into a directory named after the reference without the extension
+  ref_dir <- gsub(".tar.gz", "", ref)
+  untar(ref, exdir = "./")
   # Read the SummarizedExperiment object from the provided path
-  reference <- loadHDF5SummarizedExperiment(dir = ref)
+  reference <- loadHDF5SummarizedExperiment(dir = ref_dir)
   stopifnot(
     reflabel %in% colnames(colData(reference))
   )

--- a/subworkflows/local/celldex_reference_processing/main.nf
+++ b/subworkflows/local/celldex_reference_processing/main.nf
@@ -5,29 +5,24 @@ workflow CELLDEX_REFERENCE_PROCESSING {
     reference_string
 
     main:
-    def refdirs = Channel.empty()
+    def reftars = Channel.empty()
     def ref_list = reference_string.split(',').collect{it.trim()}
     def to_download = []
 
-    ref_list.each { r ->
-        def referencedir = r ==~ /celldex_.*_h5_se/ ? file(r) : file("celldex_${r}_h5_se")
-
-        if (!referencedir.exists()) {
-            to_download << r // Appending to the list using the left-shift operator
-        } else if (referencedir.isDirectory()) {
-            def assaysFile = file("${r}/assays.h5")
-            def seFile = file("${r}/se.rds")
-            if (seFile.exists() && assaysFile.exists()) {
-                refdirs = refdirs.mix(Channel.value(referencedir))
-            } else {
-                error "Directory ${referencedir} exists but doesn't contain the expected 'assays.h5' and 'se.rds' files"
-            }
-        }
+ref_list.each { r ->
+    def tarfile = r ==~ /.*celldex_.*_h5_se\.tar\.gz/ ? file(r) : file("celldex_${r}_h5_se.tar.gz")
+    if (!tarfile.exists()) {
+        to_download << r // Appending to the list using the left-shift operator
+    } else if (tarfile.isFile()) {
+        reftars = reftars.mix(Channel.value(tarfile))
+    } else {
+        error "Expected zip file ${tarfile} does not exist or is not a file"
     }
+}
 
     if (to_download.size() > 0) {
         Channel.fromList(to_download) | CELLTYPES_CELLDEXDOWNLOAD
-        refdirs = refdirs.mix(CELLTYPES_CELLDEXDOWNLOAD.out.refdir)
+        reftars = reftars.mix(CELLTYPES_CELLDEXDOWNLOAD.out.tar)
     }
-    emit: referenceDirs = refdirs.collect()
+    emit: referenceTars = reftars.collect()
 }

--- a/workflows/scdownstream.nf
+++ b/workflows/scdownstream.nf
@@ -77,7 +77,7 @@ workflow SCDOWNSTREAM {
         //
         if (params.celldex_reference) {
             CELLDEX_REFERENCE_PROCESSING(params.celldex_reference)
-            CELLTYPE_ASSIGNMENT(ch_h5ad, CELLDEX_REFERENCE_PROCESSING.out.referenceDirs)
+            CELLTYPE_ASSIGNMENT(ch_h5ad, CELLDEX_REFERENCE_PROCESSING.out.referenceTars)
         } else {
             CELLTYPE_ASSIGNMENT(ch_h5ad, Channel.empty())
         }


### PR DESCRIPTION
**Enabled offline testing of the singleR module.**

I changed how reference(s) are provided, instead of a directory, now it should be a `.tar.gz` file. This enabled easier hosting of references on GitHub. Nextflow can now smartly stage these files. Hence, offline works.

In order to implement this, I had to modify multiple modules, hence smaller changes in different files.

`test_full` and `test_offline` works.

References are currently staged in my GitHub fork of the nf-core test_datasets but I have created another pull request for that. The paths will be updated in the `test_offline` once the pull is merged.