### PR TITLE
FIX qcreport fail on macOS

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -233,7 +233,8 @@ process {
     }
 
     withName: QC_REPORT {
-        container = 'community.wave.seqera.io/library/jupyter_papermill_quarto_scanpy:9e9bb958ba849e57'
+        docker.registry = 'docker.io'
+        container = 'saditya88/qcreport:0.1.0'
         label = 'process_medium'
         ext.prefix = 'qc-report'
         publishDir = [


### PR DESCRIPTION
# macOS Tahoe: Kernel error #

This error occurs when running on a MacBook with latest OS.

Core error: `Kernel didn't respond in 60 seconds`

Obvious fix: The issue isn't fixed by increasing the timeout.

## The subset of error

```sh
Starting python3 kernel...2026-03-04 14:26:04,530 - traitlets - ERROR - Error occurred while starting new kernel client for kernel cac38e34-cea8-4ec1-9ed1-d777cbf3df50: Kernel didn't respond in 60 seconds


Kernel didn't respond in 60 seconds
WARN: Error encountered when rendering files
```
## How can I replicate?

Running the `test` config with `Docker` on an `arm64` based MacBook with macOS Tahoe or later.

## The fix

A new multi-arch docker container was built: `saditya88/qcreport:0.1.0`
This natively supports `aarch64` and `amd64` and the error is circumvented.

## Further reading

Error has been reported earlier on Seqera forum: https://community.seqera.io/t/quarto-jupyter-engine-error-when-running-seqera-docker-container-on-an-apple-silicon-mac/2570/3