### PR TITLE
fixed: profile test_full had obsolete implementation of celldex refer…

### DIFF
--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -27,8 +27,7 @@ params {
     integration_methods = 'scvi,harmony,bbknn,combat'
     doublet_detection   = 'solo,scrublet,doubletdetection,scds'
     celltypist_model    = 'Adult_Human_Skin'
-    celldex_reference   = 'hpca__2024-02-26,monaco_immune__2024-02-26' // Feature: Support offline.
-    celldex_reference_label = 'label.main,label.fine'
+    celldex_reference   = 'https://raw.githubusercontent.com/nf-core/test-datasets/scdownstream/singleR/references.csv'
     integration_hvgs    = 500
     scvi_max_epochs     = 5
 }


### PR DESCRIPTION
# What is this PR?

## Minor bug fix

The `test_full` config profile was still using the obsolete method for assigning `singleR` celldex references. Fixed to use the up to date `csv` method.

# How can I re-create this issue?

Running the pipeline with `test_full` config will fail with `celldex_reference` errors and warning about assigning unset variable `celldex_reference_label`

# What works now?

The `test_full` profile now functions as intended without these reference errors.