### PR TITLE
Pixified: Much smaller container footprint

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -243,7 +243,7 @@ process {
     }
 
     withName: QC_REPORT {
-        container = 'docker.io/saditya88/qcreport:0.1.0'
+        container = 'docker.io/saditya88/qcreport:0.1.1'
         label = 'process_medium'
         ext.prefix = 'qc-report'
         publishDir = [


### PR DESCRIPTION
# Much smaller container footprint #

## Why this PR?

This is a way of reducing the container footprint, making a long term impact on both usage costs, storage requirements and possibly carbon footprint.

## What has changed?

There is a new Docker container for the `QC_REPORT` module that uses `Pixi` and multi-stage multi-arch build, keeping the container smaller (compressed ~520MB from 1.82GB).

Just one line in the `conf/modules.config` has changed where the container version has been bumped to `0.1.1` from `0.1.0`, the previous version is still available as a contingency.

## Did you test?

Tested to work with the `test_full` profile on a MacBook Pro M4 Max.

**Note: Possibly test on a Linux 64 machine?**